### PR TITLE
Support transaction callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "yarn@1.22.19",
   "name": "immerhin",
   "version": "0.1.2",
   "description": "Send patches around to keep the system in sync.",


### PR DESCRIPTION
At the moment transaction queue management done internally which has a few downsides.

1. Queue is singleton though store can have multiple instances.

2. There is no way to react on any changes in store, only implement infinite loop and get data from queue.

Here I added store.subscribe method which is called every time transaction is applied to store and every time tranaction is added to queue.

This let us use own version of queue and react on any changes in the store without polling queue.