### PR TITLE
Skip empty transactions and changes

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -16,8 +16,8 @@ type UnwrapContainers<Containers extends Array<ValueContainer<unknown>>> = {
   [Index in keyof Containers]: Containers[Index] extends ValueContainer<
     infer Value
   >
-    ? Value
-    : never;
+  ? Value
+  : never;
 };
 
 export class Store {
@@ -67,6 +67,10 @@ export class Store {
       const value = finishDraft(
         draft,
         (patches: Array<Patch>, revisePatches: Array<Patch>) => {
+          // ignore empty changes
+          if (patches.length === 0) {
+            return;
+          }
           transaction.add({
             namespace,
             patches,

--- a/src/transactions-manager.ts
+++ b/src/transactions-manager.ts
@@ -30,6 +30,10 @@ export class TransactionsManager {
   }
 
   add(transaction: Transaction, source?: string) {
+    // ignore empty transactions
+    if (transaction.specs.length === 0) {
+      return;
+    }
     transaction.applyPatches();
     this.currentStack.push(transaction);
     this.callback(transaction.id, transaction.getChanges(), source);


### PR DESCRIPTION
Immerhin often puts stuff which was not changed into transactions which may bloat requests. Here's skip changes without patches and transactions without changes. So calling createTransactions without any change would not trigger requests.