### PR TITLE
Replace bson-objectid with nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "bson-objectid": "^2.0.3",
-    "immer": "^9.0.12"
+    "immer": "^9.0.12",
+    "nanoid": "^3.3.6"
   },
   "files": [
     "dist",

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,4 +1,4 @@
-import ObjectId from "bson-objectid";
+import { nanoid } from "nanoid";
 import { applyPatches, type Patch } from "immer";
 import { type ValueContainer } from "./types";
 
@@ -19,7 +19,7 @@ export class Transaction {
   id: string;
   specs: Array<TransactionSpec> = [];
   constructor() {
-    this.id = ObjectId().toString();
+    this.id = nanoid();
   }
   applyPatches() {
     for (const change of this.specs) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,11 +536,6 @@ browserslist@^4.17.5:
     node-releases "^2.0.2"
     picocolors "^1.0.0"
 
-bson-objectid@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/bson-objectid/-/bson-objectid-2.0.3.tgz#d840185172846b2f10c42ce2bcdb4a50956a9db5"
-  integrity sha512-WYwVtY9yqk179EPMNuF3vcxufdrGLEo2XwqdRVbfLVe9X6jLt7WKZQgP+ObOcprakBGbHxzl76tgTaieqsH29g==
-
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -1124,6 +1119,11 @@ ms@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+nanoid@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
 node-releases@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Webstudio switched to nanoid for json ids some time ago. Here switched immerhin too. Used nanoid v3 with cjs support. Will try to bump to v4 later.