### PR TITLE
Move queue sync logic into store

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { Store } from "./store";
+export { Store } from "./store";
 export type { Change } from "./transaction";
-export { sync, type SyncItem } from "./sync-queue";
-export { Store };
+export type { SyncItem } from "./sync-queue";

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,7 +5,7 @@ import {
   type TransactionCallback,
   TransactionsManager,
 } from "./transactions-manager";
-import { enqueue } from "./sync-queue";
+import { type Queue, enqueue, popAll } from "./sync-queue";
 
 enablePatches();
 
@@ -28,10 +28,12 @@ export class Store {
 
   private callbacks: TransactionCallback[] = [];
 
+  private queue: Queue = []
+
   constructor() {
     this.transactionManager = new TransactionsManager(
       (transactionId, changes, source) => {
-        enqueue(transactionId, changes);
+        enqueue(this.queue, transactionId, changes);
         for (const callback of this.callbacks) {
           callback(transactionId, changes, source);
         }
@@ -112,5 +114,9 @@ export class Store {
 
   redo() {
     this.transactionManager.redo();
+  }
+
+  popAll() {
+    popAll(this.queue)
   }
 }

--- a/src/sync-queue.ts
+++ b/src/sync-queue.ts
@@ -1,13 +1,14 @@
-import { type Change } from "./transaction";
+import type { Change } from "./transaction";
 
 export type SyncItem = {
   transactionId: string;
   changes: Array<Change>;
 };
 
-const queue: Array<SyncItem> = [];
+export type Queue = SyncItem[]
 
-const dequeue = (transactionId: string) => {
+
+const dequeue = (queue: Queue, transactionId: string) => {
   const index = queue.findIndex(
     (entry) => entry.transactionId === transactionId
   );
@@ -16,18 +17,18 @@ const dequeue = (transactionId: string) => {
   return true;
 };
 
-export const enqueue = (transactionId: string, changes: Array<Change>) => {
+export const enqueue = (queue: Queue, transactionId: string, changes: Array<Change>) => {
   // We are trying to delete that transaction from the queue,
   // if it was not found - we are adding the patches, because they are new
   // if it was found - we don't add it because it is technically an undo operation.
   // This can happen if user runs undo before sync happened, so we we are avoiding
   // sending it to the server unnecessarily.
-  if (dequeue(transactionId) === false) {
+  if (dequeue(queue, transactionId) === false) {
     queue.push({ transactionId, changes });
   }
 };
 
-export const sync = () => {
+export const popAll = (queue: Queue) => {
   if (queue.length === 0) return [];
   const queueCopy = [...queue];
   queue.splice(0);


### PR DESCRIPTION
Shared queue for multiple stores compliates synchronization with server in case for some stores sync is not needed.

Here moved queue into store and replaced sync() utility with store.popAll() method.