### PR TITLE
Added warning messages and validation of namespace in register method

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -42,8 +42,19 @@ export class Store {
   }
 
   register<Value>(namespace: string, container: ValueContainer<Value>) {
+    if (this.namespaces.has(container) {
+        console.warn(`The store "${container}" was already registered under a different namespace "${this.namespaces.get(container)}". The existing namespace for this store has been overwritten by the new namespace.`);
+    }
+    if (this.containers.has(namespace)) {
+        console.warn(`The namespace "${namespace}" was already used to register a different store: "${this.containers.get(namespace)}". The existing store with this namespace has been overwritten by the new store.`);
+    }
+    if (typeof namespace !== 'string' || namespace.trim() === '') {
+        throw new Error(
+          "Invalid namespace provided. It must be a non-empty string."
+        );
+    }
     this.namespaces.set(container, namespace);
-    this.containers.set(namespace, container);
+    this.containers.set(namespace.trim(), container);
   }
 
   createTransaction<Containers extends Array<ValueContainer<Any>>>(


### PR DESCRIPTION
I have made some small edits that might enhance the experience

– Additional Warning Messages:
Added the warning messages to be more descriptive and accurate when a namespace or container is already registered. This clarification aids developers in understanding the implications of overwriting existing registrations, thereby enhancing the debugging process.

– Namespace Whitespace Trimming:
Added trim method to namespace parameter to remove any whitespace before and after a string to avoid potential problems

– Namespace Validation:
Added a check to validate that the namespace parameter is a non-empty string before proceeding with the registration process. This validation helps in catching errors earlier and provides clear feedback when an invalid namespace is provided.