### PR TITLE
Allow to add and revert transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://github.com/webstudio-is/immerhin#readme",
   "devDependencies": {
     "esbuild": "^0.18.15",
+    "prettier": "^3.3.3",
     "typescript": "^5.1.6"
   },
   "dependencies": {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -18,8 +18,8 @@ type TransactionSpec = {
 export class Transaction {
   id: string;
   specs: Array<TransactionSpec> = [];
-  constructor() {
-    this.id = nanoid();
+  constructor(id = nanoid()) {
+    this.id = id;
   }
   applyPatches() {
     for (const change of this.specs) {

--- a/src/transactions-manager.ts
+++ b/src/transactions-manager.ts
@@ -3,7 +3,7 @@ import type { Change, Transaction } from "./transaction";
 export type TransactionCallback = (
   transactionId: string,
   changes: Array<Change>,
-  source?: string
+  source?: string,
 ) => void;
 
 export class TransactionsManager {
@@ -11,7 +11,7 @@ export class TransactionsManager {
   currentStack: Array<Transaction> = [];
   undoneStack: Array<Transaction> = [];
 
-  constructor(private callback: TransactionCallback) {}
+  constructor(private callback: TransactionCallback) { }
 
   undo() {
     const transaction = this.currentStack.pop();
@@ -43,5 +43,14 @@ export class TransactionsManager {
     // After we add a change, we can't redo something we have undone before.
     // It would make undo unpredictable, because there are new changes.
     this.undoneStack.splice(0);
+  }
+
+  revert(transactionId: string) {
+    const transactionIndex = this.currentStack.findIndex(
+      (transaction) => transaction.id === transactionId,
+    );
+    const transaction = this.currentStack[transactionIndex];
+    transaction.applyRevisePatches();
+    this.currentStack.splice(transactionIndex, 1);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,6 +150,11 @@ nanoid@^5.0.1:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.1.tgz#3e95d775a8bc8a98afbf0a237e2bbc6a71b0662e"
   integrity sha512-vWeVtV5Cw68aML/QaZvqN/3QQXc6fBfIieAlu05m7FZW2Dgb+3f0xc0TTxuJW+7u30t7iSDTV/j3kVI0oJqIfQ==
 
+prettier@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
+
 typescript@^5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"


### PR DESCRIPTION
Currently we use createTransactionFromChanges to sync external transactions. Though there is one problem with it. It looses transaction id which makes it impossible to revert specific transaction in case of permission error.

Here added to new methods addTransaction and revertTransaction.